### PR TITLE
CU-tn93fk: Fix RA state issues

### DIFF
--- a/packages/react-ameliorate-component-context-provider/source/context-provider.js
+++ b/packages/react-ameliorate-component-context-provider/source/context-provider.js
@@ -11,6 +11,8 @@ export const ContextProvider = componentFactory('ContextProvider', ({ Parent, co
     };
 
     construct() {
+      super.construct.apply(this, arguments);
+
       this._contextCache = {};
     }
 

--- a/packages/react-ameliorate-component-field/source/field.js
+++ b/packages/react-ameliorate-component-field/source/field.js
@@ -57,7 +57,7 @@ export const Field = componentFactory('Field', ({ Parent, componentName }) => {
     }
 
     componentMounted() {
-      super.componentMounted();
+      super.componentMounted.apply(this, arguments);
 
       if (this.props.skipFormRegistration)
         return;
@@ -72,7 +72,7 @@ export const Field = componentFactory('Field', ({ Parent, componentName }) => {
     }
 
     componentUnmounting() {
-      super.componentUnmounting();
+      super.componentUnmounting.apply(this, arguments);
 
       var parentForm = this.getParentForm();
       if (parentForm)

--- a/packages/react-ameliorate-component-form/source/form.js
+++ b/packages/react-ameliorate-component-form/source/form.js
@@ -25,6 +25,8 @@ export const Form = componentFactory('Form', ({ Parent, componentName }) => {
     };
 
     construct() {
+      super.construct.apply(this, arguments);
+
       this._registeredFields = {};
     }
 

--- a/packages/react-ameliorate-component-form/source/form.js
+++ b/packages/react-ameliorate-component-form/source/form.js
@@ -31,7 +31,7 @@ export const Form = componentFactory('Form', ({ Parent, componentName }) => {
     }
 
     componentMounted() {
-      super.componentMounted();
+      super.componentMounted.apply(this, arguments);
 
       var parentForm = this.getParentForm();
       if (parentForm)
@@ -39,7 +39,7 @@ export const Form = componentFactory('Form', ({ Parent, componentName }) => {
     }
 
     componentUnmounting() {
-      super.componentUnmounting();
+      super.componentUnmounting.apply(this, arguments);
 
       var parentForm = this.getParentForm();
       if (parentForm)

--- a/packages/react-ameliorate-component-paper/source/paper.js
+++ b/packages/react-ameliorate-component-paper/source/paper.js
@@ -335,6 +335,8 @@ export const Paper = componentFactory('Paper', ({ Parent, componentName }) => {
     }
 
     componentMounted() {
+      super.componentMounted.apply(this, arguments);
+
       this._updateInterval = setInterval(this.doUpdatePosition, 50);
     }
 
@@ -342,7 +344,8 @@ export const Paper = componentFactory('Paper', ({ Parent, componentName }) => {
       clearInterval(this._updateInterval);
 
       this.removeFromOverlay({ props: { id: this.props.id } });
-      super.componentUnmounting();
+
+      return super.componentUnmounting.apply(this, arguments);
     }
 
 

--- a/packages/react-ameliorate-component-select-field/source/select-field.js
+++ b/packages/react-ameliorate-component-select-field/source/select-field.js
@@ -29,14 +29,6 @@ export const SelectField = componentFactory('SelectField', ({ Parent, componentN
       disableSearch: PropTypes.bool
     };
 
-    componentMounted() {
-      super.componentMounted();
-    }
-
-    componentUnmounting() {
-      super.componentUnmounting();
-    }
-
     resolveProps() {
       var props = super.resolveProps.apply(this, arguments);
 

--- a/packages/react-ameliorate-core/source/component-base.js
+++ b/packages/react-ameliorate-core/source/component-base.js
@@ -136,12 +136,6 @@ export default class ComponentBase {
         configurable: true,
         value: {}
       },
-      '_raVolatileState': {
-        writable: true,
-        enumerable: false,
-        configurable: true,
-        value: {}
-      },
       '_raStateUpdateCounter': {
         writable: true,
         enumerable: false,
@@ -931,6 +925,8 @@ export default class ComponentBase {
       var stateUpdate = stateUpdates[i];
       this.setStatePassive(stateUpdate, false, false);
     }
+
+    this._raQueuedStateUpdates = [];
 
     if (doUpdate === false)
       return true;

--- a/packages/react-ameliorate-core/source/component-base.js
+++ b/packages/react-ameliorate-core/source/component-base.js
@@ -296,9 +296,13 @@ export default class ComponentBase {
 
   _destruct() {
     this.destruct();
+
+    if (this._raComponentMountedState !== 'destruct')
+      console.error(`${this.getComponentName()}: "destruct" failure: "super.destruct" call missed somewhere in your call chain. Please ensure to always call "super.destruct" in all your "destruct" lifecycle hooks.`);
   }
 
   destruct() {
+    this._raComponentMountedState = 'destruct';
   }
 
   _construct() {
@@ -320,7 +324,7 @@ export default class ComponentBase {
     this.construct();
 
     if (this._raComponentMountedState !== 'construct')
-      console.error(`${this.getComponentName()}: "construct" failure: "super.construct" call missed somewhere in your call chain. Please ensure to always call "super.construct" in all your lifecycle hooks.`);
+      console.error(`${this.getComponentName()}: "construct" failure: "super.construct" call missed somewhere in your call chain. Please ensure to always call "super.construct" in all your "construct" lifecycle hooks.`);
 
     this._invokeResolveState(false, false, true, this._raReactProps);
     this._invokeComponentWillMount();
@@ -537,6 +541,10 @@ export default class ComponentBase {
     return false;
   }
 
+  isResolvingState() {
+    return this._raResolvingStateInProgress;
+  }
+
   _invokeResolveState() {
     try {
       this._raResolvingStateInProgress = true;
@@ -639,7 +647,7 @@ export default class ComponentBase {
     this.componentMounting();
 
     if (this._raComponentMountedState !== 'mounting')
-      console.error(`${this.getComponentName()}: "componentMounting" failure: "super.componentMounting" call missed somewhere in your call chain. Please ensure to always call "super.componentMounting" in all your lifecycle hooks.`);
+      console.error(`${this.getComponentName()}: "componentMounting" failure: "super.componentMounting" call missed somewhere in your call chain. Please ensure to always call "super.componentMounting" in all your "componentMounting" lifecycle hooks.`);
   }
 
   _invokeComponentDidMount() {
@@ -649,7 +657,7 @@ export default class ComponentBase {
     this.componentMounted();
 
     if (this._raComponentMountedState !== 'mounted')
-      console.error(`${this.getComponentName()}: "componentMounted" failure: "super.componentMounted" call missed somewhere in your call chain. Please ensure to always call "super.componentMounted" in all your lifecycle hooks.`);
+      console.error(`${this.getComponentName()}: "componentMounted" failure: "super.componentMounted" call missed somewhere in your call chain. Please ensure to always call "super.componentMounted" in all your "componentMounted" lifecycle hooks.`);
   }
 
   _invokeComponentWillUnmount() {
@@ -659,7 +667,7 @@ export default class ComponentBase {
       this.clearAllDelays();
 
       if (this._raComponentMountedState !== 'unmounting')
-        console.error(`${this.getComponentName()}: "componentUnmounting" failure: "super.componentUnmounting" call missed somewhere in your call chain. Please ensure to always call "super.componentUnmounting" in all your lifecycle hooks.`);
+        console.error(`${this.getComponentName()}: "componentUnmounting" failure: "super.componentUnmounting" call missed somewhere in your call chain. Please ensure to always call "super.componentUnmounting" in all your "componentUnmounting" lifecycle hooks.`);
 
       return ret;
     } finally {

--- a/packages/react-ameliorate-core/source/component-base.js
+++ b/packages/react-ameliorate-core/source/component-base.js
@@ -136,6 +136,12 @@ export default class ComponentBase {
         configurable: true,
         value: {}
       },
+      '_raVolatileState': {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: {}
+      },
       '_raStateUpdateCounter': {
         writable: true,
         enumerable: false,
@@ -201,6 +207,12 @@ export default class ComponentBase {
         enumerable: false,
         configurable: true,
         value: {}
+      },
+      '_raResolvingStateInProgress': {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: false
       },
       'props': {
         writable: true,
@@ -307,18 +319,6 @@ export default class ComponentBase {
 
     this.construct();
 
-    // Call mixin "construct" initializers
-    var mixins = InstanceClass._raMixins;
-    if (mixins && mixins.length) {
-      for (var i = 0, il = mixins.length; i < il; i++) {
-        var mixin = mixins[i],
-            constructFunc = mixin.prototype['construct'];
-
-        if (typeof constructFunc === 'function')
-          constructFunc.call(this);
-      }
-    }
-
     this._invokeResolveState(false, false, true, this._raReactProps);
     this._invokeComponentWillMount();
   }
@@ -390,10 +390,6 @@ export default class ComponentBase {
       },
       set: () => {}
     });
-  }
-
-  _forceReactComponentUpdate() {
-    this._raReactComponent.forceUpdate();
   }
 
   _invalidateRenderCache() {
@@ -514,7 +510,7 @@ export default class ComponentBase {
 
         updateRenderState(elems);
         this._raRenderAsyncResult = true;
-        this._forceReactComponentUpdate();
+        this._reactComponentForceUpdate();
       }).catch((error) => {
         updateRenderState(null);
         throw new Error(error);
@@ -524,10 +520,6 @@ export default class ComponentBase {
     } else if (elements !== undefined) {
       return updateRenderState(elements);
     }
-  }
-
-  _setReactComponentState(newState, doneCallback) {
-    return this._raReactComponent.setState(newState, doneCallback);
   }
 
   _resolveState(initial, props, _props) {
@@ -542,7 +534,16 @@ export default class ComponentBase {
     return false;
   }
 
-  _invokeResolveState(propsUpdated, stateUpdated, initial, newProps, ...args) {
+  _invokeResolveState() {
+    try {
+      this._raResolvingStateInProgress = true;
+      return this.__invokeResolveState.apply(this, arguments);
+    } finally {
+      this._raResolvingStateInProgress = false;
+    }
+  }
+
+  __invokeResolveState(_propsUpdated, stateUpdated, initial, newProps, ...args) {
     const getResolvedProps = (force) => {
       if (force !== true && this._raResolvedPropsCache && !initial && !propsUpdated && !stateUpdated)
         return this._raResolvedPropsCache;
@@ -554,8 +555,9 @@ export default class ComponentBase {
       return formattedProps;
     };
 
-    var oldProps = this.props,
-        props = getResolvedProps(this.shouldClearInternalPropsCache(newProps, initial)),
+    var propsUpdated  = _propsUpdated,
+        oldProps      = this.props,
+        props         = getResolvedProps(this.shouldClearInternalPropsCache(newProps, initial)),
         newState,
         shouldRender;
 
@@ -569,14 +571,15 @@ export default class ComponentBase {
     try {
       newState = this._resolveState.call(this, initial, props, oldProps, ...args);
     } finally {
+      // Call prop update hooks
+      if (initial || props !== this._raResolvedPropsCache) {
+        this.props = this._raResolvedPropsCache = props;
+        this._invokeStateOrPropKeyUpdates(false, initial, props, oldProps);
+        propsUpdated = true;
+      }
+
       // Now flush the queue of state updates
       shouldRender = this.queueStateUpdates(false);
-    }
-
-    if (initial || props !== this._raResolvedPropsCache) {
-      this.props = this._raResolvedPropsCache = props;
-      this._invokeStateOrPropKeyUpdates(false, initial, props, oldProps);
-      return true;
     }
 
     return (propsUpdated || stateUpdated || shouldRender);
@@ -616,7 +619,7 @@ export default class ComponentBase {
 
   _invokeComponentDidMount() {
     if (this._raStateUpdateCounter > this._raReactComponent._stateUpdateCounter)
-      this._setReactComponentState(this.getState());
+      this._reactComponentSetState(this.getState());
 
     this.componentMounted();
   }
@@ -918,11 +921,11 @@ export default class ComponentBase {
     if (this._raQueueStateUpdatesSemaphore > 0)
       return;
 
-    var stateUpdates = this._raQueuedStateUpdates,
-        oldState = this._raInternalState;
-
+    var stateUpdates = this._raQueuedStateUpdates;
     if (!stateUpdates.length)
       return false;
+
+    var oldState = this._raInternalState;
 
     for (var i = 0, il = stateUpdates.length; i < il; i++) {
       var stateUpdate = stateUpdates[i];
@@ -932,14 +935,22 @@ export default class ComponentBase {
     if (doUpdate === false)
       return true;
 
-    this._invokeStateOrPropKeyUpdates(true, false, this.getState(), oldState);
-    this._invalidateRenderCache();
+    if (!areObjectsEqualShallow(oldState, this._raInternalState)) {
+      this._invokeStateOrPropKeyUpdates(true, false, this.getState(), oldState);
+
+      this._raStateUpdateCounter++;
+      this._invalidateRenderCache();
+    }
 
     return true;
   }
 
   canUpdateState() {
     return (this.mounted() && !this.areUpdatesFrozen() && this._raIsRenderingSemaphore <= 0);
+  }
+
+  _reactComponentSetState(newState, doneCallback) {
+    return this._raReactComponent.__setState(newState, doneCallback);
   }
 
   setStatePassive(_newState, initial, invokeUpdates, debug) {
@@ -962,22 +973,25 @@ export default class ComponentBase {
     if (debug)
       debugger;
 
-    var oldState = this._raInternalState,
-        currentState = this._raInternalState = Object.assign({}, oldState, newState);
+    var oldState      = this._raInternalState,
+        currentState  = this._raInternalState = Object.assign({}, oldState, newState);
 
     if (debug)
       debugger;
 
-    if (!areObjectsEqualShallow(oldState, currentState))
-      this._raStateUpdateCounter++;
+    if (invokeUpdates === false)
+      return newState;
+
+    // setState({}) should always trigger a re-render
+    if ((typeof newState === 'object' && Object.keys(newState).length > 0) && areObjectsEqualShallow(oldState, currentState))
+      return newState;
 
     if (typeof this._debugStateUpdates === 'function')
       this._debugStateUpdates(currentState, oldState, newState);
 
-    if (invokeUpdates !== false) {
-      this._invokeStateOrPropKeyUpdates(true, initial, currentState, oldState);
-      this._invalidateRenderCache();
-    }
+    this._raStateUpdateCounter++;
+    this._invokeStateOrPropKeyUpdates(true, initial, currentState, oldState);
+    this._invalidateRenderCache();
 
     return newState;
   }
@@ -986,7 +1000,7 @@ export default class ComponentBase {
     var newState = this.setStatePassive(_newState, undefined, undefined, debug);
 
     if (this.canUpdateState()) {
-      this._setReactComponentState(newState, doneCallback);
+      this._reactComponentSetState(newState, doneCallback);
     } else if (__DEV__) {
       var { shouldDebugRender, debugRenderGroup, componentName } = this._shouldDebugRender(this.props, this.getState());
       if (shouldDebugRender)
@@ -994,6 +1008,17 @@ export default class ComponentBase {
     }
 
     return newState;
+  }
+
+  _reactComponentForceUpdate(callback) {
+    this._raStateUpdateCounter++;
+    this._invalidateRenderCache();
+
+    return this._raReactComponent.__forceUpdate(callback);
+  }
+
+  forceUpdate(callback) {
+    return this._reactComponentForceUpdate(callback);
   }
 
   getState(path, defaultValue) {

--- a/packages/react-ameliorate-core/source/react-component-base.js
+++ b/packages/react-ameliorate-core/source/react-component-base.js
@@ -124,6 +124,14 @@ export default class ReactComponentBase extends React.Component {
     return super.forceUpdate.apply(this, arguments);
   }
 
+  setState() {
+    return this._componentInstance.setState.apply(this._componentInstance, arguments);
+  }
+
+  forceUpdate() {
+    return this._componentInstance.forceUpdate.apply(this._componentInstance, arguments);
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
     const handleUpdate = () => {
       // Props have changed... update componentInstance

--- a/packages/react-ameliorate-core/source/react-component-base.js
+++ b/packages/react-ameliorate-core/source/react-component-base.js
@@ -2,8 +2,7 @@ import {
   areObjectsEqualShallow,
   copyPrototypeFuncs,
   RAContext,
-  calculateObjectDifferences,
-  nextTick
+  calculateObjectDifferences
 }                                     from '@react-ameliorate/utils';
 
 import React                          from 'react';
@@ -115,6 +114,16 @@ export default class ReactComponentBase extends React.Component {
     return this._componentInstance;
   }
 
+  // alias for React setState
+  __setState() {
+    return super.setState.apply(this, arguments);
+  }
+
+  // alias for React forceUpdate
+  __forceUpdate() {
+    return super.forceUpdate.apply(this, arguments);
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
     const handleUpdate = () => {
       // Props have changed... update componentInstance
@@ -144,6 +153,7 @@ export default class ReactComponentBase extends React.Component {
         this._stateUpdateCounter = this._componentInstance._raStateUpdateCounter;
 
       var shouldUpdate = this._componentInstance._invokeResolveState.call(this._componentInstance, propsDiffer, statesDiffer, false, nextProps);
+
       if (!shouldUpdate && this._stateUpdateCounter < this._componentInstance._raStateUpdateCounter) {
         this._stateUpdateCounter = this._componentInstance._raStateUpdateCounter;
         shouldUpdate = true;

--- a/packages/react-ameliorate-mixin-child-handler/source/child-handler.js
+++ b/packages/react-ameliorate-mixin-child-handler/source/child-handler.js
@@ -1,4 +1,6 @@
-export function ChildHandler({ Parent, componentName }) {
+import { mixinFactory } from '@react-ameliorate/core';
+
+export const ChildHandler = mixinFactory('ChildHandler', ({ Parent, componentName }) => {
   const eventFuncMapping = {
     'entering': 'onEntering',
     'entered': 'onEntered',
@@ -208,4 +210,4 @@ export function ChildHandler({ Parent, componentName }) {
       return { changed: hasChanged, childMap: newChildren };
     }
   };
-}
+});


### PR DESCRIPTION
There were multiple issues at play here:
1. The first and largest issue was that the state queue (`_raQueuedStateUpdates`) was never being cleared. This means that components just kept adding to the queue infinitely. This was a memory leak, caused the entire app to slow down, and also was contributing to state updates getting corrupt (in very rare edge-cases)
2. The second issue is that components were being leaked on death due to the lifecycle hooks not properly making "super" calls down the chain. Updated RA to log an error when it detects that a "super" call in lifecycle hooks is missing
3. Another issue is that `setState` and `forceUpdate` calls, when called directly on the React instance of a component, weren't properly being redirected to RA. This was very inefficient as it would always cause multiple re-renders, and it also caused state updates to happen outside the RA state system, meaning they may not get properly captured on the state queue during resolve.
4. The remainder of the updates here are efficiency improvements